### PR TITLE
Kan-136 코드 병합 오류 해결

### DIFF
--- a/app/(root)/workspace/layout.tsx
+++ b/app/(root)/workspace/layout.tsx
@@ -1,28 +1,18 @@
-'use client';
-
 import { ReactNode } from 'react';
-import { useRecoilState } from 'recoil';
 
 import FloatingInfo from '@/components/chatting/FloatingInfo';
 import WithAccessToken from '@/components/hoc/WithAccessToken';
-import Sidebar from '@/components/sidebar/Sidebar';
 import { WebsocketProvider } from '@/lib/websocket/WebsocketProvider';
-import { getMenuButtonState } from '@/stores/atoms/getMenuButton';
 
 const WorkspaceLayout = ({
 	children,
 }: Readonly<{
 	children: ReactNode;
 }>) => {
-	const [isSidebarOpen] = useRecoilState(getMenuButtonState);
-
 	return (
 		<WebsocketProviderWithAccessToken>
 			<div className="flex h-full">
-				<Sidebar />
-				<section className={`${isSidebarOpen.isOpen ? 'hidden' : 'block'} py-[40px] px-[50px] w-full sm:block`}>
-					{children}
-				</section>
+				<section className={`py-[40px] px-[50px] w-full sm:block`}>{children}</section>
 				<div className="fixed bottom-0 right-[2vw] p-4">
 					<FloatingInfo />
 				</div>

--- a/app/(root)/workspace/layout.tsx
+++ b/app/(root)/workspace/layout.tsx
@@ -12,7 +12,9 @@ const WorkspaceLayout = ({
 	return (
 		<WebsocketProviderWithAccessToken>
 			<div className="flex h-full">
-				<section className={`py-[40px] px-[50px] w-full sm:block`}>{children}</section>
+				<section className="py-[40px] px-[50px] fixed top-[60px] right-0 w-full sm:w-[calc(100vw-300px)]">
+					{children}
+				</section>
 				<div className="fixed bottom-0 right-[2vw] p-4">
 					<FloatingInfo />
 				</div>

--- a/app/(root)/workspace/layout.tsx
+++ b/app/(root)/workspace/layout.tsx
@@ -12,7 +12,7 @@ const WorkspaceLayout = ({
 	return (
 		<WebsocketProviderWithAccessToken>
 			<div className="flex h-full">
-				<section className="py-[40px] px-[50px] fixed top-[60px] right-0 w-full sm:w-[calc(100vw-300px)]">
+				<section className="py-[40px] px-[50px] fixed top-[60px] right-0 w-full sm:w-[calc(100vw-300px)] h-[calc(100vh-60px)] overflow-auto">
 					{children}
 				</section>
 				<div className="fixed bottom-0 right-[2vw] p-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 
 import Header from '@/components/header/Header';
+import Sidebar from '@/components/sidebar/Sidebar';
 import { Toaster } from '@/components/ui/toaster';
 import RecoilRootProvider from '@/lib/recoil/RecoilRootProvider';
 import { pretendard } from '@/utils/fonts';
@@ -25,6 +26,7 @@ export default function RootLayout({
 			<body className={`${pretendard.variable} font-pretendard w-full flex justify-center min-h-screen`}>
 				<RecoilRootProvider>
 					<Header />
+					<Sidebar />
 					<div className="w-full max-w-[1440px] flex-1 max-h-[calc(100vh-60px)] absolute top-[60px] h-full overflow-auto">
 						{children}
 					</div>

--- a/components/RoundedButton.tsx
+++ b/components/RoundedButton.tsx
@@ -14,7 +14,6 @@ export interface RoundedButtonProps
 const buttonVariants = cva('rounded-[100px] h-fit w-fit', {
 	variants: {
 		size: {
-			Xsmall: 'w-8 h-8 rounded-full h-auto',
 			Small: 'gap-[10px] min-w-[100px] h-10 !typo-Body3 h-9',
 			Medium: 'gap-2 min-w-[268px] !typo-Body1 h-10',
 			Large: 'gap-[10px] !typo-SubHeader2 w-[600px] h-[56px]',

--- a/components/chatting/Chatting.tsx
+++ b/components/chatting/Chatting.tsx
@@ -14,6 +14,8 @@ import {
 import { getWorkspaceInfo, getWorkspaceMembers } from '@/apis/workspace';
 import { AutoSizeTextarea } from '@/components/AutoSizeTextarea';
 import ChatContainer from '@/components/chatting/ChatContainer';
+import Icon from '@/components/Icon';
+import { colors } from '@/constants/colors';
 import { useAddMessage } from '@/hooks/addMessage';
 import { useGetAccessToken } from '@/hooks/auth';
 import { useWebsocket } from '@/lib/websocket/WebsocketProvider';
@@ -192,7 +194,7 @@ export default function Chatting() {
 						<p className="typo-SubHeader3">채팅</p>
 					</div>
 					<PopoverClose>
-						<Image src="/icons/close.svg" alt="close chatting" width={15} height={15} />
+						<Icon id="close" width={15} height={15} color={colors['Gray-500']} />
 					</PopoverClose>
 				</div>
 

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -2,19 +2,48 @@ import { headers } from 'next/headers';
 
 import SidebarButton from './SidebarButton';
 
+import Logo from '@/components/header/Logo';
 import UserInfo from '@/components/header/UserInfo';
 import { UrlType } from '@/constants/url';
-import { isOnboardingUrl } from '@/utils/url';
+import { cn } from '@/lib/utils';
+import { isOnboardingUrl, isWorkspaceUrl } from '@/utils/url';
 
 const Header = () => {
-	const headersList = headers();
-	const headerPathname = headersList.get('x-current-path') || '';
-	const isPlainHeader = isOnboardingUrl(headerPathname as UrlType);
+	const headerList = headers();
+	const headerPathname = headerList.get('x-pathname') || '';
+	const isOnboarding = isOnboardingUrl(headerPathname as UrlType);
+	const isWorkspace = isWorkspaceUrl(headerPathname as UrlType);
+
+	const renderLeftContent = () => {
+		if (isWorkspace) {
+			return (
+				<>
+					<SidebarButton />
+					<Logo className="hidden sm:block" />
+				</>
+			);
+		}
+
+		return <Logo />;
+	};
+
+	const renderRightContent = () => {
+		if (isOnboarding) {
+			return null;
+		}
+
+		return <UserInfo />;
+	};
 
 	return (
-		<header className="fixed top-0 h-[60px] w-full bg-black flex px-[30px] sm:px-[60px] justify-between">
-			<SidebarButton />
-			{!isPlainHeader && <UserInfo />}
+		<header
+			className={cn(
+				'fixed top-0 h-[60px] w-full bg-black flex px-[30px] sm:px-[60px]',
+				!isOnboarding && 'justify-between',
+			)}
+		>
+			{renderLeftContent()}
+			{renderRightContent()}
 		</header>
 	);
 };

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -9,8 +9,7 @@ import { cn } from '@/lib/utils';
 import { isOnboardingUrl, isWorkspaceUrl } from '@/utils/url';
 
 const Header = () => {
-	const headerList = headers();
-	const headerPathname = headerList.get('x-pathname') || '';
+	const headerPathname = headers().get('x-pathname') || '';
 	const isOnboarding = isOnboardingUrl(headerPathname as UrlType);
 	const isWorkspace = isWorkspaceUrl(headerPathname as UrlType);
 

--- a/components/header/InviteButton.tsx
+++ b/components/header/InviteButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import InviteUser from '@/components/dialog/InviteUser';
 import CopyLinkButton from '@/components/header/CopyLinkButton';
@@ -10,23 +10,12 @@ import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 const InviteButton = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const closeDialog = () => setIsOpen(false);
-	const [isWideScreen, setIsWideScreen] = useState(window.innerWidth >= 640);
-
-	useEffect(() => {
-		const handleResize = () => {
-			setIsWideScreen(window.innerWidth >= 640);
-		};
-		window.addEventListener('resize', handleResize);
-		return () => {
-			window.removeEventListener('resize', handleResize);
-		};
-	}, []);
 
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
 			<DialogTrigger asChild>
-				<RoundedButton variant="Purple" size={isWideScreen ? 'Small' : 'Xsmall'}>
-					+ {isWideScreen ? '초대하기' : ''}
+				<RoundedButton variant="Purple" size="Small">
+					+ 초대하기
 				</RoundedButton>
 			</DialogTrigger>
 			<DialogContent className="max-w-[700px] items-center flex flex-col gap-[48px]">

--- a/components/header/Logo.tsx
+++ b/components/header/Logo.tsx
@@ -1,0 +1,18 @@
+import Image, { ImageProps } from 'next/image';
+
+import { cn } from '@/lib/utils';
+
+const Logo = ({ className, ...props }: Omit<ImageProps, 'src' | 'alt' | 'width' | 'height'>) => {
+	return (
+		<Image
+			{...props}
+			src="/icons/kan_text_horizontal.svg"
+			alt="조은사이 가로 로고"
+			width="0"
+			height="0"
+			className={cn('w-[150px] h-auto', className)}
+		/>
+	);
+};
+
+export default Logo;

--- a/components/header/SidebarButton.tsx
+++ b/components/header/SidebarButton.tsx
@@ -15,8 +15,8 @@ const SidebarButton = () => {
 
 	if (sidebarOpen.isOpen) {
 		return (
-			<button onClick={controlSidebar}>
-				<Icon id="close" color={colors['White']} size={24} />
+			<button onClick={controlSidebar} className="block sm:hidden">
+				<Icon id="close" color={colors['White']} size={20} />
 			</button>
 		);
 	}

--- a/components/header/SidebarButton.tsx
+++ b/components/header/SidebarButton.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { MenuIcon } from 'lucide-react';
-import Image from 'next/image';
 import { useRecoilState } from 'recoil';
 
+import Icon from '@/components/Icon';
+import { colors } from '@/constants/colors';
 import { getMenuButtonState } from '@/stores/atoms/getMenuButton';
 
 const SidebarButton = () => {
@@ -12,18 +13,15 @@ const SidebarButton = () => {
 		setSidebarOpen({ isOpen: !sidebarOpen.isOpen });
 	};
 
-	return (
-		<div className="gap-4 flex">
-			<MenuIcon color="white" className="block sm:hidden h-auto w-8" onClick={controlSidebar} />
-			<Image
-				src="/icons/kan_text_horizontal.svg"
-				alt="조은사이 가로 로고"
-				width="0"
-				height="0"
-				className="w-[80px] sm:w-[150px] h-auto"
-			/>
-		</div>
-	);
+	if (sidebarOpen.isOpen) {
+		return (
+			<button onClick={controlSidebar}>
+				<Icon id="close" color={colors['White']} size={24} />
+			</button>
+		);
+	}
+
+	return <MenuIcon color="white" className="block sm:hidden h-auto w-8" onClick={controlSidebar} />;
 };
 
 export default SidebarButton;

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar = () => {
 
 	return (
 		<aside
-			className={`${isSidebarOpen.isOpen ? 'block' : 'hidden'} sm:block w-screen sm:w-[100px] lg:min-w-[180px] lg:w-[296px] h-full py-[10px] px-4 custom-shadow bg-White z-50`}
+			className={`${isSidebarOpen.isOpen ? 'block' : 'hidden'} fixed left-0 top-[60px] sm:block w-screen lg:w-[300px] h-[calc(100vh-60px)] py-[10px] px-4 custom-shadow bg-White z-50`}
 		>
 			<SidebarTitle />
 			{sidebarRoutings.map(({ label, path, icon }) => {

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar = () => {
 
 	return (
 		<aside
-			className={`${isSidebarOpen.isOpen ? 'block' : 'hidden'} fixed left-0 top-[60px] sm:block w-screen lg:w-[300px] h-[calc(100vh-60px)] py-[10px] px-4 custom-shadow bg-White z-50`}
+			className={`${isSidebarOpen.isOpen ? 'block' : 'hidden'} fixed left-0 top-[60px] sm:block w-screen sm:w-[300px] h-[calc(100vh-60px)] py-[10px] px-4 custom-shadow bg-White z-50`}
 		>
 			<SidebarTitle />
 			{sidebarRoutings.map(({ label, path, icon }) => {

--- a/components/sidebar/SidebarLink.tsx
+++ b/components/sidebar/SidebarLink.tsx
@@ -29,7 +29,7 @@ const SidebarLink = ({ label, path, icon, isActive }: SidebarLinkProps) => {
 			onClick={controlSidebar}
 		>
 			<Icon id={icon} color={isActive ? colors['Purple-500'] : colors['Gray-400']} size={20} />
-			<span className="block sm:hidden lg:block">{label}</span>
+			<span>{label}</span>
 		</Link>
 	);
 };

--- a/components/sidebar/SidebarTitle.tsx
+++ b/components/sidebar/SidebarTitle.tsx
@@ -2,7 +2,7 @@ const SidebarTitle = () => {
 	return (
 		<div className="flex gap-[10px] py-[10px] items-center">
 			<span className="typo-SubHeader3 min-w-fit">카테고리</span>
-			<hr className="h-[1.5px] bg-Gray-400 border-0 w-full hidden lg:block" />
+			<hr className="h-[1.5px] bg-Gray-400 border-0 w-full" />
 		</div>
 	);
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,4 +20,13 @@ export async function middleware(request: NextRequest) {
 			return NextResponse.redirect(absoluteURL.toString());
 		}
 	}
+
+	const headers = new Headers(request.headers);
+	headers.set('x-pathname', pathname);
+
+	return NextResponse.next({
+		request: {
+			headers: headers,
+		},
+	});
 }

--- a/public/icons/icons.svg
+++ b/public/icons/icons.svg
@@ -70,4 +70,8 @@
         </clipPath>
         </defs>
     </symbol>
+    <symbol viewBox="0 0 20 20" id="close">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M1.28399 0L20 18.716L18.716 20L0 1.28399L1.28399 0Z"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M20 1.28399L1.28399 20L1.2111e-06 18.716L18.716 -6.59474e-08L20 1.28399Z"/>
+    </symbol>
 </svg>

--- a/types/icons.ts
+++ b/types/icons.ts
@@ -10,4 +10,5 @@ export type IconId =
 	| 'palette'
 	| 'webcam-off'
 	| 'microphone-off'
-	| 'screen-off';
+	| 'screen-off'
+	| 'close';


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

-   [x] PR 제목: [지라 티켓 번호] 작업 내용 한 줄 요약 ex. KAN-1 프론트엔드 개발 환경 세팅
-   [x] commit message 가 적절한지 확인해주세요.
-   [x] 적절한 branch 로 요청했는지 확인해주세요.
-   [x] Assignees, Label 을 붙여주세요.
-   [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
-   [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 📎 변경한 이유
지난 두 pr을 병합한 이후 client component에서 서버에서 할 수 있는 동작을 요청한다는 오류가 발생하였습니다.
또한, 반응형을 css가 아닌 window 사이즈를 통해 제어하는 코드가 존재하였는데, 해당 코드는 서버 단에서 호출될 경우 window 객체를 찾을 수 없기 때문에 오류가 발생하였고, 일부 반응형 사이즈가 통일되지 않아 스타일링이 제대로 적용되지 않는 화면 사이즈가 생겨 break point `sm` 사이즈를 기준으로 통일하였습니다.

## 🔄 변경 사항

<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->
- 모바일 사이즈에서 sidebar를 열었을 경우 별도의 닫기 버튼을 보여주는 것이 필요하다고 판단하여 close icon을 추가하였습니다.
- 모바일 환경에서 sidebar를 열기 위한 메뉴 아이콘과 로고를 모두 보여줄 필요가 없다고 판단하여 모바일일 경우에는 메뉴 아이콘을, 데스크탑일 경우에는 로고를 보이도록 변경하였습니다. (워크스페이스일 때 해당 조건을 따르고 그 외 페이지에서는 로고만 보이도록 설정하였습니다.)
- 위 변경을 만들자 아무리 작은 모바일 핸드폰이더라도 헤더 영역이 좁지 않아 초대하기 버튼을 줄일 필요가 없어졌다고 판단하여 기존 초대하기 버튼 코드를 살렸습니다.
![image](https://github.com/user-attachments/assets/2db0fa13-5acb-4d0c-a07d-579c9e69a723)
- 워크스페이스 layout에서 token을 가져오는 hoc를 사용하기 위해서는 해당 layout이 server component여야 하기 때문에 sidebar의 위치를 루트 layout으로 변경하였습니다. (사실 해당 sidebar는 header에게 책임이 있다고 판단하여 그 안으로 넣을까했는데 그러면 header 코드가 너무 더러워질 것 같아서 header 위치와 동일한 depth에 두되, url과 화면 사이즈에 따라 적절한 sidebar가 렌더링되도록 설정하였습니다.)
- next에서 기본적으로 제공되는 pathname 가져오는 hook은 클라이언트 컴포넌트에서만 사용 가능하기 때문에, middleware단에서 현재 pathname을 가져올 수 있는 header를 추가해주어 server component에서도 pathname을 가져올 수 있도록 하였습니다.
![image](https://github.com/user-attachments/assets/89aa70d0-da37-4c0a-b4e8-de14d9ae4b74)
- 기존 코드를 적용할 경우, 로그인 페이지에서 sidebar를 열 수 있는 버튼이 노출되는 버그가 있었습니다. 해당 버그도 해결하였습니다.

<br/>

## 📌 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->
작업하는 중에 url이 바뀌어도 header의 재렌더링이 일어나지 않아 아이콘이나 로그인 버튼 등에 적절한 변경이 일어나지 않는 버그가 발생했었는데 다시 해보니 안 나타나서 이 상태로 pr을 날리게 되었습니다.
혹시 목격하게 되시면 백로그에 추가해주세요!
<br/>
당장 작업이 가능하도록 빠르게 수정할 수 있는 방법대로 작업했는데 시간이 난다면 [이 코드](https://github.com/mui/mui-toolpad/blob/f38dd6399f56d414bdcf2cd4d12e12eec9b8c618/packages/toolpad-core/src/DashboardLayout/DashboardLayout.tsx) 참고해서 작업해도 좋을 것 같습니다!
해당 코드로 작업한 예제는 [여기서](https://mui.com/toolpad/core/react-dashboard-layout/) 보실 수 있습니다.